### PR TITLE
Remove "eslint" prefix from rule

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   rules: {
     'arrow-body-style': ['error', 'as-needed'],
-    'eslint arrow-parens': ['error', 'as-needed'],
+    'arrow-parens': ['error', 'as-needed'],
     'arrow-spacing': 'error',
     'constructor-super': 'error',
     'no-class-assign': 'error',


### PR DESCRIPTION
Должно поправить ошибку с не найденным правилом "eslint arrow-parens", т.к. правило должно быть "arrow-parens", потому что содержится в самом eslint.
Не уверен на 100%, так как не тестировал. А не тестировал, потому что не знаю, как. Но хуже точно не станет)
